### PR TITLE
fix(pre-commit): `check-renovate` requires a dependency

### DIFF
--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
         args: ["--verbose"]
       - id: check-renovate
         name: Check Renovate config with check-jsonschema
+        additional_dependencies: [json5==0.9.14]
         args: ["--verbose"]
   - repo: https://github.com/rubocop-hq/rubocop
     rev: v1.57.0


### PR DESCRIPTION
* `json5` is required to check JSON5 files
